### PR TITLE
Minor fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-GO=CGO_ENABLED=0 go
-GODOCKER=CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go
+GO=CGO_ENABLED=1 go
+GODOCKER=CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go
 TAG=latest
 BIN=bigbrother
 IMAGE=dailyhotel/$(BIN)
@@ -9,7 +9,7 @@ build:
 	$(GO) build -a -installsuffix cgo -o bin/$(BIN) .
 
 test: build
-	$(GO) test -coverprofile=coverage.txt -covermode=atomic
+	$(GO) test -race -coverprofile=coverage.txt -covermode=atomic
 
 image:
 	glide install

--- a/README.md
+++ b/README.md
@@ -8,6 +8,25 @@
 
 Do you want to know how frequently your ELBs change their own IP addresses? **bigbrother** will help you to find out it!
 
+## IAM permissions
+
+``` json
+{
+ "Version": "2012-10-17",
+ "Statement": [
+   {
+     "Effect": "Allow",
+     "Action": [
+       "elasticloadbalancing:DescribeLoadBalancers"
+     ],
+     "Resource": [
+       "*"
+     ]
+   }
+ ]
+}
+```
+
 ## How to configure
 
 The following environment variables can be configured:


### PR DESCRIPTION
- Enable CGO
- Describe IAM permissions, which is required to make bigbrother run on AWS